### PR TITLE
Added markdown generator logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,13 +148,13 @@ function generateMarkdown(){
     md += '#Planet Name: ' + document.getElementById('planetName').value + '<br>';
   }
   if (document.getElementById('starName').value !== ""){
-    md += '<br>#Star Name: ' + document.getElementById('starName').value;
+    md += '<br>#Star Name: ' + document.getElementById('starName').value + '<br>';
   }
   if (document.getElementById('region').value !== ""){
     md += '#Region: ' + document.getElementById('region').value + '<br>';
   }
   if (document.getElementById('discoverer').value !== ""){
-    md += '#Discoverer: ' + document.getElementById('discoverer').value;
+    md += '#Discoverer: ' + document.getElementById('discoverer').value + '<br>';
   }
   if (md !== ""){
     md += '<br><br>';
@@ -210,7 +210,7 @@ function generateMarkdown(){
       md += '<br><br>';
       var bullets = arr[i].querySelectorAll('.input input');
       for (var j = 0; j < bullets.length; j++){
-        md += '* '+ bullets[j].value +'<br>';
+        md += '* '+ bullets[j].value +'<br><br>';
       }
     }
   }
@@ -225,7 +225,7 @@ function generateMarkdown(){
       md += '<br><br>';
       var bullets = arr[i].querySelectorAll('.input input');
       for (var j = 0; j < bullets.length; j++){
-        md += '* '+ bullets[j].value +'<br>';
+        md += '* '+ bullets[j].value +'<br><br>';
       }
     }
   }
@@ -240,7 +240,7 @@ function generateMarkdown(){
       md += '<br><br>';
       var bullets = arr[i].querySelectorAll('.input input');
       for (var j = 0; j < bullets.length; j++){
-        md += '* '+ bullets[j].value +'<br>';
+        md += '* '+ bullets[j].value +'<br><br>';
       }
     }
   }
@@ -273,7 +273,7 @@ function generateMarkdown(){
       md += '<br><br>';
       var bullets = arr[i].querySelectorAll('.input input');
       for (var j = 0; j < bullets.length; j++){
-        md += '* '+ bullets[j].value +'<br>';
+        md += '* '+ bullets[j].value +'<br><br>';
       }
     }
   }
@@ -288,7 +288,7 @@ function generateMarkdown(){
       md += '<br><br>';
       var bullets = arr[i].querySelectorAll('.input input');
       for (var j = 0; j < bullets.length; j++){
-        md += '* '+ bullets[j].value +'<br>';
+        md += '* '+ bullets[j].value +'<br><br>';
       }
     }
   }

--- a/main.js
+++ b/main.js
@@ -44,7 +44,7 @@ function addAddButton(parent){
     button.addEventListener('click', function(){addInput(this.parentNode);});
   else
     button.addEventListener('click', function(){addDetail(this.parentNode);});
-  
+
   parent.appendChild(button);
 }
 function addRemoveButton(parent){
@@ -140,89 +140,156 @@ function generateJSON(){
   return JSON.stringify(obj);
 }
 function generateMarkdown(){
-  var md = '#Beacon Number: ' + document.getElementById('beacon').value + '<br>#Planet Name: ' + document.getElementById('planetName').value + '<br>#Star Name: ' + document.getElementById('starName').value + '<br>#Region: ' + document.getElementById('region').value + '<br>#Discoverer: ' + document.getElementById('discoverer').value + '<br><br>##Space Features: <br><br>';
+  var md = "";
+  if (document.getElementById('beacon').value !== ""){
+    md += '#Beacon Number: ' + document.getElementById('beacon').value + '<br>';
+  }
+  if (document.getElementById('planetName').value !== ""){
+    md += '#Planet Name: ' + document.getElementById('planetName').value + '<br>';
+  }
+  if (document.getElementById('starName').value !== ""){
+    md += '<br>#Star Name: ' + document.getElementById('starName').value;
+  }
+  if (document.getElementById('region').value !== ""){
+    md += '#Region: ' + document.getElementById('region').value + '<br>';
+  }
+  if (document.getElementById('discoverer').value !== ""){
+    md += '#Discoverer: ' + document.getElementById('discoverer').value;
+  }
+  if (md !== ""){
+    md += '<br><br>';
+  }
   var arr = document.querySelectorAll('#spaceFeatures input');
-  for (var i = 0; i < arr.length; i++){
-    md += '* '+ arr[i].value +'<br>';
+  if (arr.length !== 0){
+    md += '##Space Features: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      md += '* '+ arr[i].value +'<br>';
+    }
+    md += '<br><br>';
   }
-  md += '<br>##Planet Features: <br><br>###Atmosphere: <br><br>'
+  //if any of the subsections of "planet features" have data, then add the features heading
+  if (document.querySelector('#atmosphere input') ||
+      document.querySelector('#ground input') ||
+      document.querySelector('#groundPlants .detail') ||
+      document.querySelector('#trees .detail') ||
+      document.querySelector('#groundAnimals .detail') ||
+      document.querySelector('#water input') ||
+      document.querySelector('#waterPlants .detail') ||
+      document.querySelector('#fish .detail')){
+    md += '##Planet Features: <br><br>'
+  }
   var arr = document.querySelectorAll('#atmosphere input');
-  for (var i = 0; i < arr.length; i++){
-    md += '* '+ arr[i].value +'<br>';
+  if (arr.length !== 0){
+    md += '###Atmosphere: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      md += '* '+ arr[i].value +'<br>';
+    }
+    md += '<br>'
   }
-  md += '<br>###General Description: <br><br>'
+  if (document.querySelector('#ground input') ||
+      document.querySelector('#groundPlants .detail') ||
+      document.querySelector('#trees .detail') ||
+      document.querySelector('#groundAnimals .detail')){
+    md += '###Ground:';
+  }
   var arr = document.querySelectorAll('#ground input');
-  for (var i = 0; i < arr.length; i++){
-    md += '* '+ arr[i].value +'<br>';
+  if (arr.length !== 0){
+    md += '<br>###General Description: <br><br>'
+    for (var i = 0; i < arr.length; i++){
+      md += '* '+ arr[i].value +'<br>';
+    }
   }
-  md += '<br>###Ground: <br>####Plants: <br><br>';
   var arr = document.querySelectorAll('#groundPlants .detail');
-  for (var i = 0; i < arr.length; i++){
-    if (arr[i].querySelector('.image').value)
-      md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
-    else
-      md += '**' + arr[i].querySelector('.name').value + '**';
-    md += '<br><br>';
-    var bullets = arr[i].querySelectorAll('.input input');
-    for (var j = 0; j < bullets.length; j++){
-      md += '* '+ bullets[j].value +'<br>';
+  if(arr.length !== 0){
+    md += '<br>####Plants: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      if (arr[i].querySelector('.image').value)
+        md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
+      else
+        md += '**' + arr[i].querySelector('.name').value + '**';
+      md += '<br><br>';
+      var bullets = arr[i].querySelectorAll('.input input');
+      for (var j = 0; j < bullets.length; j++){
+        md += '* '+ bullets[j].value +'<br>';
+      }
     }
   }
-  md += '<br>####Trees: <br><br>';
   var arr = document.querySelectorAll('#trees .detail');
-  for (var i = 0; i < arr.length; i++){
-    if (arr[i].querySelector('.image').value)
-      md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
-    else
-      md += '**' + arr[i].querySelector('.name').value + '**';
-    md += '<br><br>';
-    var bullets = arr[i].querySelectorAll('.input input');
-    for (var j = 0; j < bullets.length; j++){
-      md += '* '+ bullets[j].value +'<br>';
+  if (arr.length !== 0){
+    md += '<br>####Trees: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      if (arr[i].querySelector('.image').value)
+        md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
+      else
+        md += '**' + arr[i].querySelector('.name').value + '**';
+      md += '<br><br>';
+      var bullets = arr[i].querySelectorAll('.input input');
+      for (var j = 0; j < bullets.length; j++){
+        md += '* '+ bullets[j].value +'<br>';
+      }
     }
   }
-  md += '<br>####Ground Creatures: <br><br>';
   var arr = document.querySelectorAll('#groundAnimals .detail');
-  for (var i = 0; i < arr.length; i++){
-    if (arr[i].querySelector('.image').value)
-      md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
-    else
-      md += '**' + arr[i].querySelector('.name').value + '**';
-    md += '<br><br>';
-    var bullets = arr[i].querySelectorAll('.input input');
-    for (var j = 0; j < bullets.length; j++){
-      md += '* '+ bullets[j].value +'<br>';
+  if (arr.length !== 0){
+    md += '<br>####Ground Creatures: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      if (arr[i].querySelector('.image').value)
+        md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
+      else
+          md += '**' + arr[i].querySelector('.name').value + '**';
+      md += '<br><br>';
+      var bullets = arr[i].querySelectorAll('.input input');
+      for (var j = 0; j < bullets.length; j++){
+        md += '* '+ bullets[j].value +'<br>';
+      }
     }
   }
-  md += '<br>###Water: <br>####General Information: <br><br>'
+  if (document.querySelector('#ground input') ||
+      document.querySelector('#groundPlants .detail') ||
+      document.querySelector('#trees .detail') ||
+      document.querySelector('#groundAnimals .detail')){
+    md += '<br>';
+  }
+  if (document.querySelector('#water input') ||
+      document.querySelector('#waterPlants .detail') ||
+      document.querySelector('#fish .detail')){
+    md += '###Water:';
+  }
   var arr = document.querySelectorAll('#water input');
-  for (var i = 0; i < arr.length; i++){
-    md += '* '+ arr[i].value +'<br>';
-  }
-  md += '<br>####Plants: <br><br>';
-  var arr = document.querySelectorAll('#waterPlants .detail');
-  for (var i = 0; i < arr.length; i++){
-    if (arr[i].querySelector('.image').value)
-      md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
-    else
-      md += '**' + arr[i].querySelector('.name').value + '**';
-    md += '<br><br>';
-    var bullets = arr[i].querySelectorAll('.input input');
-    for (var j = 0; j < bullets.length; j++){
-      md += '* '+ bullets[j].value +'<br>';
+  if (arr.length !== 0){
+    md += '<br>####General Information: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      md += '* '+ arr[i].value +'<br>';
     }
   }
-  md += '<br>####Fish: <br><br>';
+  var arr = document.querySelectorAll('#waterPlants .detail');
+  if (arr.length !== 0){
+    md += '<br>####Plants: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      if (arr[i].querySelector('.image').value)
+        md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
+      else
+        md += '**' + arr[i].querySelector('.name').value + '**';
+      md += '<br><br>';
+      var bullets = arr[i].querySelectorAll('.input input');
+      for (var j = 0; j < bullets.length; j++){
+        md += '* '+ bullets[j].value +'<br>';
+      }
+    }
+  }
   var arr = document.querySelectorAll('#fish .detail');
-  for (var i = 0; i < arr.length; i++){
-    if (arr[i].querySelector('.image').value)
-      md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
-    else
-      md += '**' + arr[i].querySelector('.name').value + '**';
-    md += '<br><br>';
-    var bullets = arr[i].querySelectorAll('.input input');
-    for (var j = 0; j < bullets.length; j++){
-      md += '* '+ bullets[j].value +'<br>';
+  if (arr.length !== 0){
+    md += '<br>####Fish: <br><br>';
+    for (var i = 0; i < arr.length; i++){
+      if (arr[i].querySelector('.image').value)
+        md += '**[' + arr[i].querySelector('.name').value + '](' + arr[i].querySelector('.image').value + ')**';
+      else
+        md += '**' + arr[i].querySelector('.name').value + '**';
+      md += '<br><br>';
+      var bullets = arr[i].querySelectorAll('.input input');
+      for (var j = 0; j < bullets.length; j++){
+        md += '* '+ bullets[j].value +'<br>';
+      }
     }
   }
   return md;
@@ -237,7 +304,7 @@ function hideModal(){
 function showModal(text){
   'use strict';
   hideModal();
-  
+
   var close = document.createElement('button');
   close.innerHTML = 'Close';
   close.type = 'button';

--- a/main.js
+++ b/main.js
@@ -148,7 +148,7 @@ function generateMarkdown(){
     md += '#Planet Name: ' + document.getElementById('planetName').value + '<br>';
   }
   if (document.getElementById('starName').value !== ""){
-    md += '<br>#Star Name: ' + document.getElementById('starName').value + '<br>';
+    md += '#Star Name: ' + document.getElementById('starName').value + '<br>';
   }
   if (document.getElementById('region').value !== ""){
     md += '#Region: ' + document.getElementById('region').value + '<br>';


### PR DESCRIPTION
General enhancements to the markdown generator. 
Adds logic to the gen function that skips making headers for nonexistent data.
So, if a player is making a report that leaves certain fields blank, it previously looked like this:
# Beacon Number: Beacon
# Planet Name:
# Star Name:
# Region:
# Discoverer:
## Space Features:
- Jimmy
## Planet Features:
### Atmosphere:
- No oxygen
### General Description:
- Ground is soft, pliable
### Ground:
#### Plants:
#### Trees:

**[Palm Tree](imgur.com/stuff)**
- has leaves.
#### Ground Creatures:
### Water:
#### General Information:
#### Plants:
#### Fish:

**These changes eliminate awkward headers that don't refer to anything, leaving this:**
# Beacon Number: 4444-0000-3333
# Planet Name: Golgafrincham
# Discoverer: Ford Prefect
## Planet Features:
### Ground:
### General Description:
- Has red dirt
#### Ground Creatures:

**Dinosaurus Rex**
- Description
